### PR TITLE
Improve USB boot stability

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -517,7 +517,7 @@ export class UsbbootScanner extends EventEmitter {
 		debug('Found serial number', device.deviceDescriptor.iSerialNumber);
 		debug('port id', devicePortId(device));
 		try {
-			const { iface, endpoint } = initializeDevice(device);
+			const { endpoint } = initializeDevice(device);
 			if (device.deviceDescriptor.iSerialNumber === 0) {
 				debug('Sending bootcode.bin', devicePortId(device));
 				this.step(device, 0);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
 		"declaration": true,
 		"target": "es6",
 		"noImplicitAny": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
 		"strictNullChecks": true
 	},
 	"include": [


### PR DESCRIPTION
- Check the `INIT_ERROR` flag when initializing `libusb`
- Don't wait infinitely for USB transfers
- Retry if a bulk transfer stalls

Change-type: patch