### PR TITLE
dependencies: bump node-usb to v1.3.10 to enable Node 12 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^6.0.112",
     "@types/usb": "^1.5.1",
     "debug": "^3.1.0",
-    "usb": "github:resin-io/node-usb#1.3.6"
+    "usb": "github:resin-io/node-usb#v1.3.10"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.20",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>